### PR TITLE
Chris little patch 1

### DIFF
--- a/standard_template/standard/annex-history.adoc
+++ b/standard_template/standard/annex-history.adoc
@@ -7,5 +7,5 @@
 |Date |Release |Editor | Primary clauses modified |Description
 |2021-10-27 |0.1 |Chris Little |all |initial version
 |2021-11-03 |0.2 |Chris Little |6&7 replaced |structured version
-|2022-02-02 |0.3 |Chris Little |replace standard by specification 
+|2022-02-02 |0.3 |Chris Little |all |replace standard by specification 
 |===

--- a/standard_template/standard/annex-history.adoc
+++ b/standard_template/standard/annex-history.adoc
@@ -7,5 +7,5 @@
 |Date |Release |Editor | Primary clauses modified |Description
 |2021-10-27 |0.1 |Chris Little |all |initial version
 |2021-11-03 |0.2 |Chris Little |6&7 replaced |structured version
-|2022-02-02 |0.3 |Chris Little |all |replace standard by specification 
+|2022-02-02 |0.2.1 |Chris Little |all |replace standard by specification 
 |===

--- a/standard_template/standard/annex-history.adoc
+++ b/standard_template/standard/annex-history.adoc
@@ -7,4 +7,5 @@
 |Date |Release |Editor | Primary clauses modified |Description
 |2021-10-27 |0.1 |Chris Little |all |initial version
 |2021-11-03 |0.2 |Chris Little |6&7 replaced |structured version
+|2022-02-02 |0.3 |Chris Little |replace standard by specification 
 |===

--- a/standard_template/standard/clause_1_scope.adoc
+++ b/standard_template/standard/clause_1_scope.adoc
@@ -1,5 +1,5 @@
 == Scope
 
-The standard has been stable for several years, with a wide-spread international community in the environmental sciences. The current version of the open specification, on https://covjson.org/spec[GitHub], is labelled ‘V0.2-draft’. This document standardises that version with only editorial changes for presentation.
+The specification has been stable for several years, with a wide-spread international community in the environmental sciences. The current version of the open specification, on https://covjson.org/spec[GitHub], is labelled ‘V0.2-draft’. This document proposes that version, with only editorial changes for presentation, as a Community Standard.
 
 Future improvements have been identified, such as improving the use of multiple time dimensions, or to use JSON-LD V1.1 which may give better compatibility with CIS. These enhancements are out of scope of this document.

--- a/standard_template/standard/clause_2_conformance.adoc
+++ b/standard_template/standard/clause_2_conformance.adoc
@@ -1,8 +1,8 @@
 == Conformance
 
-Conformance with this standard shall be checked using all the relevant tests specified in Annex A (normative) of this document. The framework, concepts, and methodology for testing, and the criteria to claim conformance are specified in the OGC Compliance Testing Policies and Procedures and the OGC Compliance Testing web site.
+Conformance with this specification shall be checked using all the relevant tests specified in Annex A (normative) of this document. The framework, concepts, and methodology for testing, and the criteria to claim conformance are specified in the OGC Compliance Testing Policies and Procedures and the OGC Compliance Testing web site.
 
-The one Standardization Target for this standard is the format of CoverageJSON.
+The one Standardization Target for this specification is the format of CoverageJSON.
 
 In order to conform to this OGC® Community Standard, a software implementation shall choose to implement any one of the conformance levels specified in Annex A (normative).
 

--- a/standard_template/standard/clause_5_conventions.adoc
+++ b/standard_template/standard/clause_5_conventions.adoc
@@ -2,8 +2,8 @@
 This sections provides details and examples for any conventions used in the document. Examples of conventions are symbols, abbreviations, use of XML schema, or special notes regarding how to read the document.
 
 === Identifiers
-The normative provisions in this standard are denoted by the URI
+The normative provisions in this specification are denoted by the URI
 
-http://www.opengis.net/spec/{standard}/{m.n}
+http://www.opengis.net/spec/{specification}/{m.n}
 
 All requirements and conformance tests that appear in this document are denoted by partial URIs which are relative to this base.

--- a/standard_template/standard/clause_specification_text.adoc
+++ b/standard_template/standard/clause_specification_text.adoc
@@ -79,7 +79,7 @@ Range data can also be directly embedded into the main CoverageJSON document, ma
 
 ### 1.2. Differences to OGC Coverage Implementation Schema (CIS)
 
-The candidate OGC standard http://www.opengeospatial.org/pressroom/pressreleases/2345[Coverage Implementation Schema 1.1] (abbreviated to CIS)
+The OGC standard http://www.opengeospatial.org/pressroom/pressreleases/2345[Coverage Implementation Schema 1.1] (abbreviated to CIS)
 defines a coverage model targeted towards OGC service types like Web Coverage Service (WCS)
 and is the successor of the https://portal.opengeospatial.org/files/?artifact_id=48553
 ["GML 3.2.1 Application Schema – Coverages" version 1.0] (abbreviated to GMLCOV).

--- a/standard_template/standard/standard_document.adoc
+++ b/standard_template/standard/standard_document.adoc
@@ -20,7 +20,7 @@
 |Publication Date:   <yyyy-mm-dd>
 |External identifier of this OGC(R) document: http://www.opengis.net/doc/{doc-type}/{standard}/{m.n}
 |Internal reference number of this OGC(R) document:    21-069
-|Version: 0.2
+|Version: 0.2.1
 |Category: OGC(R) Implementation
 |Editor:   Chris Little, Jon Blower, etc
 |===

--- a/standard_template/standard/standard_document.adoc
+++ b/standard_template/standard/standard_document.adoc
@@ -48,7 +48,7 @@ Recipients of this document are invited to submit, with their comments, notifica
 
 [width = "50%", grid = "none"]
 |===
-|Document type:   	OGC® Standard
+|Document type:   	OGC® Candidate Community Standard
 |Document subtype:   	if applicable
 |Document stage:   	Draft
 |Document language: 	English


### PR DESCRIPTION
Removes reference to this document as a `standard` and uses the terminology `specification`. 

Reference to `candidate standard CIS` updated to `standard CIS`