### PR TITLE
Remove text for CIS comparison

### DIFF
--- a/standard_template/standard/clause_specification_text.adoc
+++ b/standard_template/standard/clause_specification_text.adoc
@@ -75,23 +75,7 @@ where `"http://example.com/coverages/123/TEMP"` points to the following document
   "values" : [ 27.1, 24.1, null, 25.1, ... ]
 }
 ```
-Range data can also be directly embedded into the main CoverageJSON document, making it stand-alone.
-
-### 1.2. Differences to OGC Coverage Implementation Schema (CIS)
-
-The OGC standard http://www.opengeospatial.org/pressroom/pressreleases/2345[Coverage Implementation Schema 1.1] (abbreviated to CIS)
-defines a coverage model targeted towards OGC service types like Web Coverage Service (WCS)
-and is the successor of the https://portal.opengeospatial.org/files/?artifact_id=48553
-["GML 3.2.1 Application Schema – Coverages" version 1.0] (abbreviated to GMLCOV).
-
-The model of CoverageJSON can be seen as a mix of CIS and the data cube-based https://en.wikipedia.org/wiki/NetCDF[NetCDF file format].
-
-The following lists some areas where the model used by CoverageJSON departs from CIS:
-
-- CIS enforces exactly one coordinate reference system (CRS) per coverage, CoverageJSON allows CRSs to be associated with a given combination of coordinates.
-- CIS has separate domain concepts for grids vs other types, CoverageJSON always uses collections of orthogonal axes for organizing domains, whether gridded or not.
-- CIS has no specific model for describing categories of a categorical parameter, CoverageJSON defines such a model.
-- CIS has no notion of semantically grouping parameters (e.g. velocity = speed + direction), CoverageJSON allows that.
+Range data can also be directly embedded into the main CoverageJSON document, making it standalone.
 
 ## 2. i18n Objects
 


### PR DESCRIPTION
We've removed the text about CIS comparison from the main CovJSON website so we should probably remove it here too