### PR TITLE
Clarifications to domain type specs

### DIFF
--- a/standard_template/standard/clause_specification_text.adoc
+++ b/standard_template/standard/clause_specification_text.adoc
@@ -964,8 +964,8 @@ Coverage example:
 
 ### 10.2. VerticalProfile
 
-- A domain with VerticalProfile domain type MUST have the axes `"x"`, `"y"`, and `"z"`, where `"x"` and `"y"` MUST have a single coordinate only.
-- A domain with VerticalProfile domain type MAY have the axis `"t"` which MUST have a single coordinate only.
+- A domain with VerticalProfile domain type MUST have the axes `"x"`, `"y"`, and `"z"`, where `"x"` and `"y"` MUST have a single coordinate value only.
+- A domain with VerticalProfile domain type MAY have the axis `"t"` which MUST have a single coordinate value only.
 
 Domain example:
 
@@ -1016,8 +1016,8 @@ Coverage example:
 
 ### 10.3. PointSeries
 
-- A domain with PointSeries domain type MUST have the axes `"x"`, `"y"`, and `"t"` where `"x"` and `"y"` MUST have a single coordinate only.
-- A domain with PointSeries domain type MAY have the axis `"z"` which MUST have a single coordinate only.
+- A domain with PointSeries domain type MUST have the axes `"x"`, `"y"`, and `"t"` where `"x"` and `"y"` MUST have a single coordinate value only.
+- A domain with PointSeries domain type MAY have the axis `"z"` which MUST have a single coordinate value only.
 
 Domain example:
 
@@ -1068,7 +1068,7 @@ Coverage example:
 
 ### 10.4. Point
 
-- A domain with Point domain type MUST have the axes `"x"` and `"y"` and MAY have the axes `"z"` and `"t"` where all MUST have a single coordinate only.
+- A domain with Point domain type MUST have the axes `"x"` and `"y"` and MAY have the axes `"z"` and `"t"` where all MUST have a single coordinate value only.
 
 Domain example:
 
@@ -1201,7 +1201,7 @@ Coverage example:
 
 ### 10.6. MultiPoint
 
-- A domain with MultiPoint domain type MUST have the axis `"composite"` and MAY have the axis `"t"` where `"t"` MUST have a single coordinate only.
+- A domain with MultiPoint domain type MUST have the axis `"composite"` and MAY have the axis `"t"` where `"t"` MUST have a single coordinate value only.
 - The axis `"composite"` MUST have the data type `"tuple"` and the coordinate identifiers `"x","y","z"` or `"x","y"`, in that order.
 
 Domain example:
@@ -1282,7 +1282,7 @@ Coverage example:
 
 ### 10.7. Trajectory
 
-- A domain with Trajectory domain type MUST have the axis `"composite"` and MAY have the axis `"z"` where `"z"` MUST have a single coordinate only.
+- A domain with Trajectory domain type MUST have the axis `"composite"` and MAY have the axis `"z"` where `"z"` MUST have a single coordinate value only.
 - The axis `"composite"` MUST have the data type `"tuple"` and the coordinate identifiers `"t","x","y","z"` or `"t","x","y"`, in that order.
 - The value ordering of the axis `"composite"` MUST follow the ordering of its `"t"` coordinate as defined in the corresponding reference system.
 
@@ -1453,7 +1453,7 @@ Polygons in this domain domain type are defined equally to GeoJSON, except that 
 
 - A domain with Polygon domain type MUST have the axis `"composite"` which has a single Polygon value.
 - The axis `"composite"` MUST have the data type `"polygon"` and the coordinate identifiers `"x","y"`, in that order.
-- A Polygon domain MAY have the axes `"z"` and `"t"` which both MUST have a single value only.
+- A Polygon domain MAY have the axes `"z"` and `"t"` which both MUST have a single coordinate value only.
 
 Domain example:
 
@@ -1513,7 +1513,7 @@ Coverage example:
 ### 10.10. PolygonSeries
 
 - A domain with PolygonSeries domain type MUST have the axes `"composite"` and `"t"` where `"composite"` MUST have a single Polygon value. Polygons are defined in the Polygon domain type.
-- A domain with PolygonSeries domain type MAY have the axis `"z"` which MUST have a single value only.
+- A domain with PolygonSeries domain type MAY have the axis `"z"` which MUST have a single coordinate value only.
 - The axis `"composite"` MUST have the data type `"polygon"` and the coordinate identifiers `"x","y"`, in that order.
 
 Domain example:
@@ -1577,7 +1577,7 @@ Coverage example:
 
 - A domain with MultiPolygon domain type MUST have the axis `"composite"` where the values are Polygons. Polygons are defined in the Polygon domain type.
 - The axis `"composite"` MUST have the data type `"polygon"` and the coordinate identifiers `"x","y"`, in that order.
-- A MultiPolygon domain MAY have the axes `"z"` and `"t"` which both MUST have a single value only.
+- A MultiPolygon domain MAY have the axes `"z"` and `"t"` which both MUST have a single coordinate value only.
 
 Domain example:
 
@@ -1642,7 +1642,7 @@ Coverage example:
 
 - A domain with MultiPolygonSeries domain type MUST have the axes `"composite"` and `"t"` where the values of `"composite"` are Polygons. Polygons are defined in the Polygon domain type.
 - The axis `"composite"` MUST have the data type `"polygon"` and the coordinate identifiers `"x","y"`, in that order.
-- A MultiPolygon domain MAY have the axis `"z"` which MUST have a single value only.
+- A MultiPolygon domain MAY have the axis `"z"` which MUST have a single coordinate value only.
 
 Domain example:
 

--- a/standard_template/standard/clause_specification_text.adoc
+++ b/standard_template/standard/clause_specification_text.adoc
@@ -880,7 +880,7 @@ Requirements for all domain types defined in this specification:
 `"z"` to vertical spatial coordinates, and all of `"x"`, `"y"`, and `"z"` MUST be referenced by a spatial coordinate reference system.
 - The axis and coordinate identifier `"t"` MUST refer to temporal coordinates and be referenced by a temporal reference system.
 - If a spatial CRS is used that has the axes longitude and latitude, or easting and northing, then the axis and coordinate identifier `"x"` MUST refer to longitude / easting, and `"y"` to latitude / northing.
-- A domain that states conformance to one of the domain types in this specification MAY have any number of additional one-coordinate axes not defined here.
+- A domain that states conformance to one of the domain types in this specification MUST only contain axes defined by the domain type: additional axes are not allowed.
 - In a Coverage object, the axis ordering in `"axisNames"` of NdArray objects SHOULD follow the order "t", "z", "y, "x", "composite", leaving out all axes that do not exist or are single-valued.
 
 .Domain Types table

--- a/standard_template/standard/clause_specification_text.adoc
+++ b/standard_template/standard/clause_specification_text.adoc
@@ -965,6 +965,7 @@ Coverage example:
 ### 10.2. VerticalProfile
 
 - A domain with VerticalProfile domain type MUST have the axes `"x"`, `"y"`, and `"z"`, where `"x"` and `"y"` MUST have a single coordinate only.
+- A domain with VerticalProfile domain type MAY have the axis `"t"` which MUST have a single coordinate only.
 
 Domain example:
 
@@ -1117,7 +1118,7 @@ Coverage example:
 ### 10.5. MultiPointSeries
 
 - A domain with MultiPointSeries domain type MUST have the axes `"composite"` and `"t"`.
-- The axis `"composite"` MUST have the data type `"tuple"` and the coordinate identifiers `"x","y","z"` or `"x","y"`.
+- The axis `"composite"` MUST have the data type `"tuple"` and the coordinate identifiers `"x","y","z"` or `"x","y"`, in that order.
 
 Domain example:
 
@@ -1201,7 +1202,7 @@ Coverage example:
 ### 10.6. MultiPoint
 
 - A domain with MultiPoint domain type MUST have the axis `"composite"` and MAY have the axis `"t"` where `"t"` MUST have a single coordinate only.
-- The axis `"composite"` MUST have the data type `"tuple"` and the coordinate identifiers `"x","y","z"` or `"x","y"`.
+- The axis `"composite"` MUST have the data type `"tuple"` and the coordinate identifiers `"x","y","z"` or `"x","y"`, in that order.
 
 Domain example:
 
@@ -1282,7 +1283,7 @@ Coverage example:
 ### 10.7. Trajectory
 
 - A domain with Trajectory domain type MUST have the axis `"composite"` and MAY have the axis `"z"` where `"z"` MUST have a single coordinate only.
-- The axis `"composite"` MUST have the data type `"tuple"` and the coordinate identifiers `"t","x","y","z"` or `"t","x","y"`.
+- The axis `"composite"` MUST have the data type `"tuple"` and the coordinate identifiers `"t","x","y","z"` or `"t","x","y"`, in that order.
 - The value ordering of the axis `"composite"` MUST follow the ordering of its `"t"` coordinate as defined in the corresponding reference system.
 
 Domain example:
@@ -1384,7 +1385,7 @@ Coverage example:
 ### 10.8. Section
 
 - A domain with Section domain type MUST have the axes `"composite"` and `"z"`.
-- The axis `"composite"` MUST have the data type `"tuple"` and the coordinate identifiers `"t","x","y"`.
+- The axis `"composite"` MUST have the data type `"tuple"` and the coordinate identifiers `"t","x","y"`, in that order.
 - The value ordering of the axis `"composite"` MUST follow the ordering of its `"t"` coordinate as defined in the corresponding reference system.
 
 Domain example:
@@ -1451,7 +1452,7 @@ Polygons in this domain domain type are defined equally to GeoJSON, except that 
 - A Polygon is an array of LinearRing arrays. For Polygons with multiple rings, the first MUST be the exterior ring and any others MUST be interior rings or holes.
 
 - A domain with Polygon domain type MUST have the axis `"composite"` which has a single Polygon value.
-- The axis `"composite"` MUST have the data type `"polygon"` and the coordinate identifiers `"x","y"`.
+- The axis `"composite"` MUST have the data type `"polygon"` and the coordinate identifiers `"x","y"`, in that order.
 - A Polygon domain MAY have the axes `"z"` and `"t"` which both MUST have a single value only.
 
 Domain example:
@@ -1513,7 +1514,7 @@ Coverage example:
 
 - A domain with PolygonSeries domain type MUST have the axes `"composite"` and `"t"` where `"composite"` MUST have a single Polygon value. Polygons are defined in the Polygon domain type.
 - A domain with PolygonSeries domain type MAY have the axis `"z"` which MUST have a single value only.
-- The axis `"composite"` MUST have the data type `"polygon"` and the coordinate identifiers `"x","y"`.
+- The axis `"composite"` MUST have the data type `"polygon"` and the coordinate identifiers `"x","y"`, in that order.
 
 Domain example:
 
@@ -1575,7 +1576,7 @@ Coverage example:
 ### 10.11. MultiPolygon
 
 - A domain with MultiPolygon domain type MUST have the axis `"composite"` where the values are Polygons. Polygons are defined in the Polygon domain type.
-- The axis `"composite"` MUST have the data type `"polygon"` and the coordinate identifiers `"x","y"`.
+- The axis `"composite"` MUST have the data type `"polygon"` and the coordinate identifiers `"x","y"`, in that order.
 - A MultiPolygon domain MAY have the axes `"z"` and `"t"` which both MUST have a single value only.
 
 Domain example:
@@ -1640,7 +1641,7 @@ Coverage example:
 ### 10.12. MultiPolygonSeries
 
 - A domain with MultiPolygonSeries domain type MUST have the axes `"composite"` and `"t"` where the values of `"composite"` are Polygons. Polygons are defined in the Polygon domain type.
-- The axis `"composite"` MUST have the data type `"polygon"` and the coordinate identifiers `"x","y"`.
+- The axis `"composite"` MUST have the data type `"polygon"` and the coordinate identifiers `"x","y"`, in that order.
 - A MultiPolygon domain MAY have the axis `"z"` which MUST have a single value only.
 
 Domain example:
@@ -1705,4 +1706,3 @@ Coverage example:
 ## Acknowledgements
 
 This work was inspired by a demonstration of the concept by Joan Masó of CREAF.
-


### PR DESCRIPTION
Following development of the schema, we found that the text defining domain types needed some small clarifications