### PR TITLE
Metadata: change doctype to community standard

### DIFF
--- a/standard_template/standard/document.adoc
+++ b/standard_template/standard/document.adoc
@@ -1,5 +1,5 @@
 = OGC CoverageJSON Community Standard
-:doctype: standard
+:doctype: community-standard
 :encoding: utf-8
 :lang: en
 :status: draft


### PR DESCRIPTION
cc @ghobona 

Example reference: https://raw.githubusercontent.com/metanorma/mn-samples-ogc/b3bdf688cbaf3822e00b6e3c1076ebf37530b0f6/sources/18-053r2/document.adoc