### PR TITLE
Removed "Example" heading and edited text

### DIFF
--- a/standard/clause_specification_text.adoc
+++ b/standard/clause_specification_text.adoc
@@ -8,10 +8,7 @@ CoverageJSON is a format for encoding coverage data such as grids, time series, 
 
 A complete CoverageJSON data structure is always an object (in JSON terms). In CoverageJSON, an object consists of a collection of name/value pairs -- also called members. For each member, the name is always a string. Member values are either a string, number, object, array or one of the literals: true, false, and null. An array consists of elements where each element is a value as described above.
 
-//### 1.1. Example
-==== Example
-
-A CoverageJSON grid coverage of global air temperature:
+The following is an illustrative example of using CoverageJSON to encode air temperature data on a global grid at a resolution of one degree:
 
 [%unnumbered%]
 ```json


### PR DESCRIPTION
This PR removes a third-level heading for an example document, for consistency with the rest of the specification