### PR TITLE
Added UML diagram and other minor edits

### DIFF
--- a/standard/clause_specification_text.adoc
+++ b/standard/clause_specification_text.adoc
@@ -6,12 +6,12 @@
 
 CoverageJSON is a format for encoding coverage data such as grids, time series, and vertical profiles, each distinguished by the geometry of their spatiotemporal domain. A CoverageJSON object represents a domain, a range, a coverage, or a collection of coverages. A range in CoverageJSON represents coverage values. A coverage in CoverageJSON is the combination of a domain, parameters, ranges, and additional metadata. A coverage collection represents a list of coverages.
 
-A complete CoverageJSON data structure is always an object (in JSON terms). In CoverageJSON, an object consists of a collection of name/value pairs -- also called members. For each member, the name is always a string. Member values are either a string, number, object, array or one of the literals: true, false, and null. An array consists of elements where each element is a value as described above.
+A complete CoverageJSON data structure is always an object (in JSON terms). In CoverageJSON, an object consists of a collection of name/value pairs -- also called members. For each member, the name is always a string. Member values are either a string, number, object, array or one of the literals: `true`, `false` or `null`. An array consists of elements where each element is a value as described above.
 
-//### 1.1. Example
-==== Example
+//### 1.1. Illustrative Example
+==== Illustrative Example
 
-A CoverageJSON grid coverage of global air temperature:
+The following is an illustrative example of using CoverageJSON to encode air temperature data on a global grid at a resolution of one degree:
 
 [%unnumbered%]
 ```json
@@ -81,6 +81,30 @@ where `"http://example.com/coverages/123/TEMP"` points to the following document
 }
 ```
 Range data can also be directly embedded into the main CoverageJSON document, making it standalone.
+
+//### 1.2. UML diagram
+==== UML diagram
+
+The following is a high-level UML class diagram of the main CoverageJSON objects and the relationships between them.
+
+```mermaid
+classDiagram
+    CoverageCollection "0..1" o-- "1..*" Coverage
+
+    Coverage "1" *-- "1" Domain
+    Coverage "1" *-- "1..*" Parameter
+    Coverage "1" *-- "*" ParameterGroup
+    Coverage "1" *-- "1..*" Range
+
+    Domain "1" *-- "1..*" Axis
+    Domain "1" *-- "*" ReferenceSystem
+
+    Range <|-- NdArray
+    Range <|-- TiledNdArray
+    TiledNdArray "0..1" *-- "1..*" NdArray
+
+    ParameterGroup "0..1" *-- "1..*" Parameter
+```
 
 //## 2. i18n Objects
 === i18n Objects


### PR DESCRIPTION
Added the UML conceptual diagram as per #21.

On reflection, and slightly different to what we agreed in the telecon, I thought it was worth keeping "Illustrative Example" as a heading at the same level as the UML diagram, so we should end up with:

```
Introduction
 - Illustrative Example
 - UML diagram
```

which seems to make sense to me from the point of view of someone browsing the TOC. So this would effectively cancel out the previous PR. Does that make sense to you, @chris-little?