### PR TITLE
Remove undefined terms in parameterGroup examples

### DIFF
--- a/standard/annex-history.adoc
+++ b/standard/annex-history.adoc
@@ -12,4 +12,6 @@
 |2022-05-25 |0.2.2 |Jon Blower, Gobe Hobona, Chris Little, Maik Riechert |all |final publication edits
 |2022-07-14 |0.2.3 |Chris Little, Jon Blower |all |incorporate OGC Architecture Board editorial edits
 |2022-09-14 |0.2.4 |Chris Little, Jon Blower |all |incorporate final Public Comments editorial edits
+|2023-08-22 |1.0.0 |OGC Staff |Approved OGC Community standard
+|2026-02-05 |1.0.1 |Chris Little, Kathi Schleidt |Improved JSON-LD examples
 |===

--- a/standard/clause_specification_text.adoc
+++ b/standard/clause_specification_text.adoc
@@ -254,7 +254,7 @@ Example of a group describing a vector quantity:
 ```
 where `"WIND_SPEED"` and `"WIND_DIR"` reference existing parameters in a CoverageJSON coverage or collection object by their short identifiers.
 
-Example of a group describing uncertainty of a parameter:
+Example of a group describing uncertainty of a parameter by including the mean and standard deviation:
 
 [%unnumbered%]
 ```json
@@ -295,7 +295,7 @@ where `"SST_mean"` references the following parameter:
 }
 ```
 
-and `"SST_stddev"`:
+and `"SST_stddev"` references the following parameter:
 
 [%unnumbered%]
 ```json
@@ -953,6 +953,8 @@ Note that domain axis values and range values SHOULD NOT be exposed as linked da
 
 Example:
 
+In this example, additional semantics for the registered `dct` prefix are provided by stating that the `"dct:license"` member value in this document is an identifier and not just an unstructured string.
+
 [%unnumbered%]
 ```json
 {
@@ -969,7 +971,38 @@ Example:
 }
 ```
 
-In this example, additional semantics for the registered `dct` prefix are provided by stating that the `"dct:license"` member value in this document is an identifier and not just an unstructured string.
+Example:
+
+In this example, extra attributes of the `Parameter` have been declared stating that the parameter is a more specific example in the context of a more general vocabulary. ** Note: not sure about the `statisticalMeasure` attribute and why square brackets?**
+
+[%unnumbered%]
+```json
+{
+ "@context": [
+    "https://covjson.org/context.jsonld",
+    {
+      "skos": "http://www.w3.org/2004/02/skos/core",
+    }
+  ],
+"type" : "Parameter",
+  "observedProperty" : {
+    "label" : {
+      "en": "Sea surface temperature daily mean"
+    },
+    "statisticalMeasure": "http://www.uncertml.org/statistics/mean",
+    "narrower": ["http://vocab.nerc.ac.uk/standard_name/sea_surface_temperature/"]
+  },
+  "unit" : {
+    "label": {
+      "en": "Kelvin"
+    },
+    "symbol": {
+      "value": "K",
+      "type": "http://www.opengis.net/def/uom/UCUM/"
+    }
+  }
+}
+```
 
 [[resolving_domain_and_range_urls]]
 //## 10. Resolving domain and range URLs

--- a/standard/clause_specification_text.adoc
+++ b/standard/clause_specification_text.adoc
@@ -282,9 +282,6 @@ where `"SST_mean"` references the following parameter:
     "label" : {
       "en": "Sea surface temperature daily mean"
     },
-    "statisticalMeasure": "http://www.uncertml.org/statistics/mean",
-    "statisticalPeriod": "P1D",
-    "narrowerThan": ["http://vocab.nerc.ac.uk/standard_name/sea_surface_temperature/"]
   },
   "unit" : {
     "label": {
@@ -308,8 +305,6 @@ and `"SST_stddev"`:
     "label" : {
       "en": "Sea surface temperature standard deviation of daily mean"
     },
-    "statisticalMeasure": "http://www.uncertml.org/statistics/standard-deviation",
-    "narrowerThan": ["http://vocab.nerc.ac.uk/standard_name/sea_surface_temperature/"]
   },
   "unit" : {
     "label": {

--- a/standard/clause_specification_text.adoc
+++ b/standard/clause_specification_text.adoc
@@ -973,7 +973,7 @@ In this example, additional semantics for the registered `dct` prefix are provid
 
 Example:
 
-In this example, extra attributes of the `Parameter` have been declared stating that the parameter is a more specific example in the context of a more general vocabulary. ** Note: not sure about the `statisticalMeasure` attribute and why square brackets?**
+In this example, extra attributes of the `Parameter` have been declared stating that the parameter is a more specific example in the context of a more general vocabulary.
 
 [%unnumbered%]
 ```json

--- a/standard/clause_specification_text.adoc
+++ b/standard/clause_specification_text.adoc
@@ -989,7 +989,7 @@ In this example, extra attributes of the `Parameter` have been declared stating 
     "label" : {
       "en": "Sea surface temperature daily mean"
     },
-    "statisticalMeasure": "http://www.uncertml.org/statistics/mean",
+    "statisticalMeasure": "https://web.archive.org/web/20161029215223/http://uncertml.org/statistics/mean",
     "narrower": ["http://vocab.nerc.ac.uk/standard_name/sea_surface_temperature/"]
   },
   "unit" : {

--- a/standard/clause_specification_text.adoc
+++ b/standard/clause_specification_text.adoc
@@ -982,12 +982,7 @@ In this example, extra attributes of the `Parameter` have been declared stating 
 [%unnumbered%]
 ```json
 {
- "@context": [
-    "https://covjson.org/context.jsonld",
-    {
-      "skos": "http://www.w3.org/2004/02/skos/core",
-    }
-  ],
+ "@context": [ "https://covjson.org/context.jsonld" ],
 "type" : "Parameter",
   "observedProperty" : {
     "label" : {

--- a/standard/clause_specification_text.adoc
+++ b/standard/clause_specification_text.adoc
@@ -988,7 +988,7 @@ In this example, extra attributes of the `Parameter` have been declared stating 
     "label" : {
       "en": "Sea surface temperature daily mean"
     },
-    "statisticalMeasure": "https://web.archive.org/web/20161029215223/http://uncertml.org/statistics/mean",
+    "statisticalMeasure": "https://ec.europa.eu/eurostat/statistics-explained/index.php?title=Glossary:Arithmetic_mean",
     "narrower": ["http://vocab.nerc.ac.uk/standard_name/sea_surface_temperature/"]
   },
   "unit" : {

--- a/standard/clause_specification_text.adoc
+++ b/standard/clause_specification_text.adoc
@@ -282,6 +282,8 @@ where `"SST_mean"` references the following parameter:
     "label" : {
       "en": "Sea surface temperature daily mean"
     },
+"statisticalMeasure": "https://ec.europa.eu/eurostat/statistics-explained/index.php?title=Glossary:Arithmetic_mean",
+"narrower": "http://www.w3.org/2004/02/skos/core"
   },
   "unit" : {
     "label": {
@@ -305,6 +307,8 @@ and `"SST_stddev"` references the following parameter:
     "label" : {
       "en": "Sea surface temperature standard deviation of daily mean"
     },
+"statisticalMeasure": "https://ec.europa.eu/eurostat/statistics-explained/index.php?title=Glossary:Standard_deviation",
+"narrower": "http://www.w3.org/2004/02/skos/core"
   },
   "unit" : {
     "label": {

--- a/standard/clause_specification_text.adoc
+++ b/standard/clause_specification_text.adoc
@@ -283,7 +283,7 @@ where `"SST_mean"` references the following parameter:
       "en": "Sea surface temperature daily mean"
     },
 "statisticalMeasure": "https://ec.europa.eu/eurostat/statistics-explained/index.php?title=Glossary:Arithmetic_mean",
-"narrower": "http://www.w3.org/2004/02/skos/core"
+"narrower": ["http://vocab.nerc.ac.uk/standard_name/sea_surface_temperature/"]
   },
   "unit" : {
     "label": {
@@ -308,7 +308,7 @@ and `"SST_stddev"` references the following parameter:
       "en": "Sea surface temperature standard deviation of daily mean"
     },
 "statisticalMeasure": "https://ec.europa.eu/eurostat/statistics-explained/index.php?title=Glossary:Standard_deviation",
-"narrower": "http://www.w3.org/2004/02/skos/core"
+"narrower": ["http://vocab.nerc.ac.uk/standard_name/sea_surface_temperature/"]
   },
   "unit" : {
     "label": {

--- a/standard/clause_specification_text.adoc
+++ b/standard/clause_specification_text.adoc
@@ -977,7 +977,7 @@ In this example, additional semantics for the registered `dct` prefix are provid
 
 Example:
 
-In this example, extra attributes of the `Parameter` have been declared stating that the parameter is a more specific example in the context of a more general vocabulary.
+In this example, extra attributes of the `Parameter` have been declared stating that the parameter is a more specific concept in the context of a more general vocabulary.
 
 [%unnumbered%]
 ```json

--- a/standard/clause_specification_text.adoc
+++ b/standard/clause_specification_text.adoc
@@ -282,8 +282,8 @@ where `"SST_mean"` references the following parameter:
     "label" : {
       "en": "Sea surface temperature daily mean"
     },
-"statisticalMeasure": "https://ec.europa.eu/eurostat/statistics-explained/index.php?title=Glossary:Arithmetic_mean",
-"narrower": ["http://vocab.nerc.ac.uk/standard_name/sea_surface_temperature/"]
+    "statisticalMeasure": "https://ec.europa.eu/eurostat/statistics-explained/index.php?title=Glossary:Arithmetic_mean",
+    "narrower": ["http://vocab.nerc.ac.uk/standard_name/sea_surface_temperature/"]
   },
   "unit" : {
     "label": {
@@ -307,8 +307,8 @@ and `"SST_stddev"` references the following parameter:
     "label" : {
       "en": "Sea surface temperature standard deviation of daily mean"
     },
-"statisticalMeasure": "https://ec.europa.eu/eurostat/statistics-explained/index.php?title=Glossary:Standard_deviation",
-"narrower": ["http://vocab.nerc.ac.uk/standard_name/sea_surface_temperature/"]
+    "statisticalMeasure": "https://ec.europa.eu/eurostat/statistics-explained/index.php?title=Glossary:Standard_deviation",
+    "narrower": ["http://vocab.nerc.ac.uk/standard_name/sea_surface_temperature/"]
   },
   "unit" : {
     "label": {


### PR DESCRIPTION
Removed undefined terms `narrowerThan`, `statisticalMeasure` and `statisticalPeriod` from the Parameter Group examples. Add another example to the JSON-LD section.