### PR TITLE
Update clause_2_conformance.adoc

### DIFF
--- a/standard/clause_2_conformance.adoc
+++ b/standard/clause_2_conformance.adoc
@@ -1,7 +1,9 @@
 [[conformance]]
 == Conformance
 
-Conformance with this OGC Community Standard shall be checked using the https://schemas.opengis.net/covjson/1.0/[JSON schema] files. The schema bundle has been incorporated into the https://covjson.org/playground/[CoverageJSON Community Playground] which can test files for conformance. Simple guidance on CoverageJSON is available at the https://covjson.org/cookbook/[Community Cookbook].
+Conformance with this OGC Community Standard V1.0 shall be checked using the https://schemas.opengis.net/covjson/1.0/[JSON schema V1.0] files or the https://schemas.opengis.net/covjson/1.0.1/[JSON schema V1.0.1] files. 
+
+The schema bundle has been incorporated into the https://covjson.org/playground/[CoverageJSON Community Playground] which can test files for conformance. Simple guidance on CoverageJSON is available at the https://covjson.org/cookbook/[Community Cookbook].
 
 The one Standardization Target for this OGC Community Standard is the format of CoverageJSON.
 


### PR DESCRIPTION
OpenAPI V3.1, used for defining APIs, mandates the use of JSON Schema Dialect 2020, which is not compatible with Dialect 2019 or Draft-07 which was used in CoverageJSON V1.0 and earlier. This PR adds support for both Draft-07 and 2020 dialects of JSON Schema